### PR TITLE
Add cgroupv2 support on Linux

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,7 @@ jobs:
         sudo apt-get install -y python3 python3-pip curl python3-setuptools python3-wheel python3-pytest
     - name: pip
       run: |
+        python3 -m pip install --upgrade pip
         python3 -m pip install .[test]
     - name: test
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
     - name: apt
       run: |
         sudo apt-get update
-        sudo apt-get install -y python3 python3-pip curl
+        sudo apt-get install -y python3 python3-pip curl python3-setuptools python3-wheel python3-pytest
     - name: pip
       run: |
         python3 -m pip install .[test]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,10 @@ on:
     
 jobs:
   ubuntu_test:
-    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        runs-on: [ubuntu-20.04, ubuntu-22.04]
+    runs-on: ${{ matrix.runs-on }}
     steps:
     - uses: actions/checkout@v3
     - name: apt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
         sudo apt-get install -y python3 python3-pip curl
     - name: pip
       run: |
-        pip3 install .[test]
+        python3 -m pip install .[test]
     - name: test
       run: |
         python3 -m pytest -s

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,9 @@ jobs:
       run: |
         python3 -m pip install --upgrade pip
         python3 -m pip install .[test]
+    - name: allow cgroup
+      run : |
+        sudo chown -R $(id -un):$(id -gn) /sys/fs/cgroup/system.slice/runner-provisioner.service || true
     - name: test
       run: |
         python3 -m pytest -s

--- a/drekar_launch.py
+++ b/drekar_launch.py
@@ -958,8 +958,10 @@ def main():
 
         timestamp = datetime.now().strftime("-%Y-%m-%d--%H-%M-%S")
         log_dir = Path(appdirs.user_log_dir(appname="drekar-launch")).joinpath(name).joinpath(name + timestamp)
-        log_dir.mkdir(parents=True, exist_ok=True)        
-        loop = asyncio.get_event_loop()
+        log_dir.mkdir(parents=True, exist_ok=True)
+        
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)        
                         
         exit_event = asyncio.Event()
         core = DrekarCore(parser_results.name, task_launch, exit_event, log_dir, not parser_results.quiet, loop)

--- a/drekar_launch.py
+++ b/drekar_launch.py
@@ -663,13 +663,13 @@ if sys.platform == "linux":
             sentinel_environ = os.environ.copy()
             sentinel_environ["DREKAR_LAUNCH_ENABLE_SENTINEL"] = "0"
             self.sentinel_process=subprocess.Popen([sys.executable, "-m", "drekar_launch", "--sentinel", str(os.getpid()), str(self.cgroup_path)], 
-                                                    env=sentinel_environ)
+                                                    env=sentinel_environ, close_fds=True, start_new_session=True)
             
         def stop_sentinel(self):
             if self.sentinel_process is None:
                 return
             try:                
-                os.kill(self.sentinel_process.pid, signal.SIGTERM)
+                os.killpg(self.sentinel_process.pid, signal.SIGTERM)
             except:
                 pass
 

--- a/examples/http_client_server/drekar-launch.yaml
+++ b/examples/http_client_server/drekar-launch.yaml
@@ -1,14 +1,14 @@
 name: example_http_servers
 tasks:
   - name: http_server
-    program: python.exe
+    program: python
     args: 
      - "example_http_server.py"
      - 8100
      - "Hello from server 1"
     cwd: .
   - name: http_client
-    program: curl.exe
+    program: curl
     args: http://localhost:8100
     start-delay: 2
     quit-on-terminate: true

--- a/examples/http_servers/drekar-launch.yaml
+++ b/examples/http_servers/drekar-launch.yaml
@@ -1,11 +1,11 @@
 name: example_http_servers
 tasks:
   - name: http_server_1
-    program: python.exe
+    program: python
     args: example_http_server.py 8100 Server1
     cwd: .
   - name: http_server_2
-    program: python.exe
+    program: python
     args:
       - example_http_server.py
       - 8101


### PR DESCRIPTION
This PR adds cgroupv2 support on Linux, when supported. cgroupv2 is relatively recent, and only available on Ubuntu 21.04 and greater. cgroups are used to catch subprocesses that are launched by tasks and not properly stopped. A "sentinel" process is created that will sweep up processes if they are not killed properly by a crashing or malfunctioning launcher. The sentinel can be disabled by setting the environmental variable `DREKAR_LAUNCH_ENABLE_SENTINEL=0`.

There are also a few misc improvements.